### PR TITLE
Version 0.6.5 20-6-2025 16:45

### DIFF
--- a/lib/archive/name_input_page.dart
+++ b/lib/archive/name_input_page.dart
@@ -1,5 +1,4 @@
 import '../exports/package_exports.dart';
-import '../exports/theme_exports.dart';
 import '../exports/util_exports.dart';
 import '../exports/page_exports.dart';
 
@@ -43,8 +42,10 @@ class NameInputPage extends StatelessWidget {
                         builder: (context) => MainPage(userName: name),
                       ),
                     );
-                  };
-                };
+                  }
+                  ;
+                }
+                ;
               },
               child: const Text('Continue'),
             ),

--- a/lib/data/firebase_database.dart
+++ b/lib/data/firebase_database.dart
@@ -3,6 +3,8 @@ import '../exports/package_exports.dart';
 class FirestoreDataBase with ChangeNotifier {
   Map<String, List<List<dynamic>>> _tasksByDate = {};
 
+  DateTime? _currentDay;
+
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
@@ -131,7 +133,16 @@ class FirestoreDataBase with ChangeNotifier {
   }
 
   Future<void> updateToday(DateTime newDay) async {
-    await loadDataForDate(newDay);
-    notifyListeners();
+    if (_currentDay == null || !_isSameDay(_currentDay!, newDay)) {
+      _currentDay = newDay;
+      await loadDataForDate(newDay);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        notifyListeners();
+      });
+    }
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
   }
 }

--- a/lib/exports/page_exports.dart
+++ b/lib/exports/page_exports.dart
@@ -1,5 +1,6 @@
-export '../pages/settings/default_todo_page.dart';
 export '../pages/settings/settings_provider.dart';
+export '../pages/settings/default_todo_page.dart';
+export '../pages/settings/debug_page.dart';
 export '../pages/home_page.dart';
 export '../pages/login_page.dart';
 export '../pages/main_page.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,9 +61,8 @@ class MyApp extends StatelessWidget {
             theme: theme.themeData,
             initialRoute: '/',
             routes: {
-              '/': (context) => user != null
-                  ? const MainPageLauncher()
-                  : const LoginPage(),
+              '/': (context) =>
+                  user != null ? const MainPageLauncher() : const LoginPage(),
               '/login': (context) => const LoginPage(),
               '/register': (context) => const RegisterPage(),
               '/settings': (context) => const SettingsPage(),
@@ -80,8 +79,6 @@ class MainPageLauncher extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final user = FirebaseAuth.instance.currentUser;
-    final name = user?.displayName ?? user?.email ?? 'User';
-    return MainPage(userName: name);
+    return MainPage();
   }
 }

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -57,9 +57,7 @@ class _LoginPageState extends State<LoginPage> {
                     _passwordController.text.trim(),
                   );
                   if (user != null && context.mounted) {
-                    final user = FirebaseAuth.instance.currentUser;
                     debugLog('[Login] User authenticated');
-                    final name = user?.displayName ?? user?.email ?? 'User';
                     final themeProvider =
                         Provider.of<ThemeProvider>(context, listen: false);
                     await themeProvider.loadFromFirestore();
@@ -67,7 +65,7 @@ class _LoginPageState extends State<LoginPage> {
                     Navigator.pushReplacement(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => MainPage(userName: name),
+                        builder: (context) => MainPage(),
                       ),
                     );
                   }

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -1,29 +1,26 @@
 import '../exports/package_exports.dart';
-import '../exports/theme_exports.dart';
 import '../exports/page_exports.dart';
 import '../exports/util_exports.dart';
 
 class MainPage extends StatefulWidget {
-  final String userName;
-  const MainPage({super.key, required this.userName});
+  const MainPage({super.key});
 
   @override
   State<MainPage> createState() => _MainPageState();
 }
 
 class _MainPageState extends State<MainPage> {
-  late List <Widget> pages;
-  
+  late List<Widget> pages;
+
   @override
   void initState() {
     super.initState();
     pages = [
-      HomePage(userName: widget.userName),
+      HomePage(),
       ProfilePage(),
       SettingsPage(),
     ];
   }
-  
 
   Functions f = Functions();
   int currentPage = 0;

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,7 +1,5 @@
 import '../exports/package_exports.dart';
-import '../exports/theme_exports.dart';
 import '../exports/util_exports.dart';
-import '../exports/page_exports.dart';
 
 class ProfilePage extends StatelessWidget {
   const ProfilePage({super.key});
@@ -18,6 +16,12 @@ class ProfilePage extends StatelessWidget {
           'Profile',
           style: textTheme.headlineLarge,
         ),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.logout),
+            onPressed: () => f.logout(context),
+          ),
+        ],
       ),
       body: Container(
         child: Center(
@@ -25,11 +29,6 @@ class ProfilePage extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               const Text("Profile Page Content Placeholder"),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: () => f.logout(context),
-                child: const Text('Logout'),
-              ),
             ],
           ),
         ),

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -1,5 +1,4 @@
 import '../exports/package_exports.dart';
-import '../exports/theme_exports.dart';
 import '../exports/util_exports.dart';
 import '../exports/page_exports.dart';
 
@@ -61,6 +60,11 @@ class _RegisterPageState extends State<RegisterPage> {
                 final email = _emailController.text.trim();
                 final password = _passwordController.text.trim();
 
+                if (name.isEmpty) {
+                  setState(() => _error = 'Please enter your name.');
+                  return;
+                }
+
                 try {
                   final user = await f.register(name, email, password);
                   debugLog(
@@ -69,8 +73,7 @@ class _RegisterPageState extends State<RegisterPage> {
                     Navigator.pushReplacement(
                       context,
                       MaterialPageRoute(
-                        builder: (context) =>
-                            MainPage(userName: name ?? 'User'),
+                        builder: (context) => MainPage(),
                       ),
                     );
                   }

--- a/lib/pages/settings/debug_page.dart
+++ b/lib/pages/settings/debug_page.dart
@@ -1,0 +1,42 @@
+import '../../exports/package_exports.dart';
+import '../../exports/theme_exports.dart';
+
+class DebugPage extends StatelessWidget {
+  const DebugPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: true,
+        title: Text("Debug Page", style: textTheme.headlineLarge),
+      ),
+      body: ListView(
+        children: [
+          const SizedBox(height: 16),
+          _buildColorPreview(context, "Primary", themeColor(context).primary),
+          const Divider(),
+          _buildColorPreview(
+              context, "Secondary", themeColor(context).secondary),
+          const Divider(),
+          _buildColorPreview(context, "Tertiary", themeColor(context).tertiary),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildColorPreview(BuildContext context, String label, Color color) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Container(
+        height: 50,
+        color: color,
+        child: Center(
+          child: Text('Current $label Color'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/settings/default_todo_page.dart
+++ b/lib/pages/settings/default_todo_page.dart
@@ -1,10 +1,12 @@
 import '../../exports/package_exports.dart';
 import '../../exports/theme_exports.dart';
-import '../../exports/data_exports.dart';
 
 class DefaultTodoPage extends StatefulWidget {
   final String weekday;
-  const DefaultTodoPage({required this.weekday, super.key});
+  final List<List<dynamic>> toDoList;
+
+  const DefaultTodoPage(
+      {required this.weekday, required this.toDoList, super.key});
 
   @override
   State<DefaultTodoPage> createState() => _DefaultTodoPageState();
@@ -19,11 +21,7 @@ class _DefaultTodoPageState extends State<DefaultTodoPage> {
   @override
   void initState() {
     super.initState();
-    
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await _loadDefaultDay();
-      setState(() {});
-    });
+    toDoList = widget.toDoList;
   }
 
   @override
@@ -32,43 +30,23 @@ class _DefaultTodoPageState extends State<DefaultTodoPage> {
     super.dispose();
   }
 
-  Future<void> _loadDefaultDay() async {
-    final uid = _auth.currentUser?.uid;
-    if (uid == null) return;
-
-    final doc = await _firestore
-      .collection('users')
-      .doc(uid)
-      .collection('defaultTodos')
-      .doc(widget.weekday)
-      .get();
-
-    if (doc.exists) {
-      final data = doc.data();
-      if (data != null && data['tasks'] is List) {
-        toDoList = List<List<dynamic>>.from(
-          data['tasks'].map((task) => [task['name'], task['completed']]),
-        );
-      }
-    }
-  }
-  
-
   Future<void> _save() async {
     final uid = _auth.currentUser?.uid;
     if (uid == null) return;
 
-    final tasks = toDoList.map((task) => {
-      'name': task[0],
-      'completed': task[1],
-    }).toList();
+    final tasks = toDoList
+        .map((task) => {
+              'name': task[0],
+              'completed': task[1],
+            })
+        .toList();
 
     await _firestore
-      .collection('users')
-      .doc(uid)
-      .collection('defaultTodos')
-      .doc(widget.weekday)
-      .set({'tasks': tasks});
+        .collection('users')
+        .doc(uid)
+        .collection('defaultTodos')
+        .doc(widget.weekday)
+        .set({'tasks': tasks});
   }
 
   @override
@@ -98,7 +76,7 @@ class _DefaultTodoPageState extends State<DefaultTodoPage> {
                   toDoList.insert(newIndex, item);
                 });
                 await _save();
-                if (mounted) setState (() {});
+                if (mounted) setState(() {});
               },
               children: toDoList.asMap().entries.map((entry) {
                 int index = entry.key;
@@ -117,8 +95,8 @@ class _DefaultTodoPageState extends State<DefaultTodoPage> {
                       children: [
                         ReorderableDragStartListener(
                           index: index,
-                          child:
-                              Icon(Icons.drag_handle, color: themeColor(context).tertiary),
+                          child: Icon(Icons.drag_handle,
+                              color: themeColor(context).tertiary),
                         ),
                         SizedBox(width: 12),
                         Checkbox(
@@ -129,7 +107,8 @@ class _DefaultTodoPageState extends State<DefaultTodoPage> {
                               toDoList[index][1] = !toDoList[index][1];
                             });
                             await _save();
-                            if (mounted) setState (() {});;
+                            if (mounted) setState(() {});
+                            ;
                           },
                         ),
                         Expanded(
@@ -146,7 +125,7 @@ class _DefaultTodoPageState extends State<DefaultTodoPage> {
                               toDoList.removeAt(index);
                             });
                             await _save();
-                            if (mounted) setState (() {});
+                            if (mounted) setState(() {});
                           },
                         ),
                       ],
@@ -176,12 +155,12 @@ class _DefaultTodoPageState extends State<DefaultTodoPage> {
                   ),
                   onPressed: () async {
                     if (_controller.text.trim().isEmpty) return;
-                    setState (() {
+                    setState(() {
                       toDoList.add([_controller.text.trim(), false]);
                       _controller.clear();
                     });
                     await _save();
-                    if (mounted) setState (() {});
+                    if (mounted) setState(() {});
                   },
                   child: Text("Add"),
                 ),

--- a/lib/pages/settings/settings_provider.dart
+++ b/lib/pages/settings/settings_provider.dart
@@ -2,46 +2,33 @@ import '../../exports/package_exports.dart';
 
 class SettingsProvider with ChangeNotifier {
   final FirebaseAuth _auth = FirebaseAuth.instance;
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
-
-  String _dayStartHour = '00:00';
-  String get dayStartHour => _dayStartHour;
+  //final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
   Future<void> loadSettings() async {
     final user = _auth.currentUser;
     if (user == null) return;
 
-    final docRef = _firestore
-        .collection('users')
-        .doc(user.uid)
-        .collection('settings')
-        .doc('dayStart');
-
-    final doc = await docRef.get();
-    if (doc.exists && doc.data() != null) {
-      final data = doc.data()!;
-      _dayStartHour = data['hour'] ?? '00:00';
-    } else {
-      await docRef.set({'hour': '00:00'});
-      _dayStartHour = '00:00';
-    }
+    //final docRef = _firestore
+    //.collection('users')
+    //.doc(user.uid)
+    //.collection('settings')
+    //.doc('');
 
     notifyListeners();
   }
 
-  Future<void> setDayStartHour(String hour) async {
+  Future<void> setSetting(String hour) async {
     final user = _auth.currentUser;
     if (user == null) return;
 
-    _dayStartHour = hour;
     notifyListeners();
 
-    final docRef = _firestore
-        .collection('users')
-        .doc(user.uid)
-        .collection('settings')
-        .doc('dayStart');
+    //final docRef = _firestore
+    //.collection('users')
+    //.doc(user.uid)
+    //.collection('settings')
+    //.doc('dayStart');
 
-    await docRef.set({'hour': hour});
+    //await docRef.set({'': });
   }
 }

--- a/lib/pages/todo_page.dart
+++ b/lib/pages/todo_page.dart
@@ -1,11 +1,13 @@
 import 'package:flutter_slidable/flutter_slidable.dart';
 import '../exports/package_exports.dart';
 import '../exports/theme_exports.dart';
+import '../exports/page_exports.dart';
 import '../exports/data_exports.dart';
 import '../exports/util_exports.dart';
 
 class ToDoPage extends StatefulWidget {
-  const ToDoPage({super.key});
+  final DateTime selectedDate;
+  const ToDoPage({super.key, required this.selectedDate});
 
   @override
   State<ToDoPage> createState() => _ToDoState();
@@ -17,24 +19,30 @@ class _ToDoState extends State<ToDoPage> {
   final Functions f = Functions();
   final _controller = TextEditingController();
 
-  DateTime selectedDate = DateTime.now();
+  late DateTime selectedDate;
   late DayWatcher _dayWatcher;
 
   @override
   void initState() {
     super.initState();
     db = Provider.of<FirestoreDataBase>(context, listen: false);
+    final settingsProvider = Provider.of<SettingsProvider>(context, listen: false);
+
+    selectedDate = widget.selectedDate;
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await settingsProvider.loadSettings();
       await db.loadDataForDate(selectedDate);
       setState(() {});
     });
 
-    _dayWatcher = DayWatcher(onDayChanged: (newLogicalDay) async {
-      selectedDate = newLogicalDay;
-      await db.loadDataForDate(selectedDate);
-      setState(() {});
-    });
+    _dayWatcher = DayWatcher(
+      onDayChanged: (newLogicalDay) async {
+        selectedDate = newLogicalDay;
+        await db.loadDataForDate(selectedDate);
+        setState(() {});
+      },
+    );
   }
 
   @override

--- a/lib/theme/theme_presets.dart
+++ b/lib/theme/theme_presets.dart
@@ -1,7 +1,6 @@
 import '../exports/package_exports.dart';
-import '../exports/theme_exports.dart';
 
-//pink #FFB7C5, red #FF9999, orange #FFD1A6, yellow #FFEE99, green #B2E5B2, turqoise #B2F5E5, blue #C6E2FF, dark blue #A6B8FF, purple #D1B3FF
+//pink 0xFFFFB7C5, red 0xFFFF9999, orange 0xFFFFD1A6, yellow 0xFFFFEE99, green 0xFFBFFFBF, turqoise 0xFFBFFFF0, blue 0xFFBFDFFF, dark blue 0xFFA6AAFF, purple 0xFFD1B3FF
 
 class ThemePreset {
   final String name;
@@ -19,48 +18,48 @@ class ThemePreset {
 
 final List<ThemePreset> presets = [
   ThemePreset(
-    name: 'Pink',
-    primary: Color(0xFFFFB7C5),
-    secondary: Color(0xFFFF8098),
-    tertiary: Color(0xFFBF6072)),
+      name: 'Pink',
+      primary: Color(0xFFFFB7C5),
+      secondary: Color(0xFFFF8098),
+      tertiary: Color(0xFFBF6072)),
   ThemePreset(
-    name: 'Red',
-    primary: Color(0xFFFF9999),
-    secondary: Color(0xFFFF6666),
-    tertiary: Color(0xFFBF3939)),
+      name: 'Red',
+      primary: Color(0xFFFF9999),
+      secondary: Color(0xFFFF6666),
+      tertiary: Color(0xFFBF3939)),
   ThemePreset(
-    name: 'Orange',
-    primary: Color(0xFFFFD1A6),
-    secondary: Color(0xFFFFB066),
-    tertiary: Color(0xFFBF844D)),
+      name: 'Orange',
+      primary: Color(0xFFFFD1A6),
+      secondary: Color(0xFFFFB066),
+      tertiary: Color(0xFFBF844D)),
   ThemePreset(
-    name: 'Yellow',
-    primary: Color(0xFFFFEE99),
-    secondary: Color(0xFFFFE666),
-    tertiary: Color(0xFFBFAC4D)),
+      name: 'Yellow',
+      primary: Color(0xFFFFEE99),
+      secondary: Color(0xFFFFE666),
+      tertiary: Color(0xFFBFAC4D)),
   ThemePreset(
-    name: 'Green',
-    primary: Color(0xFFBFFFBF),
-    secondary: Color(0xFF80FF80),
-    tertiary: Color(0xFF60BF60)),
+      name: 'Green',
+      primary: Color(0xFFBFFFBF),
+      secondary: Color(0xFF80FF80),
+      tertiary: Color(0xFF60BF60)),
   ThemePreset(
-    name: 'Turquoise',
-    primary: Color(0xFFBFFFF0),
-    secondary: Color(0xFF80FFE1),
-    tertiary: Color(0xFF60BFA8)),
+      name: 'Turquoise',
+      primary: Color(0xFFBFFFF0),
+      secondary: Color(0xFF80FFE1),
+      tertiary: Color(0xFF60BFA8)),
   ThemePreset(
-    name: 'Blue',
-    primary: Color(0xFFBFDFFF),
-    secondary: Color(0xFF80BEFF),
-    tertiary: Color(0xFF608FBF)),
+      name: 'Blue',
+      primary: Color(0xFFBFDFFF),
+      secondary: Color(0xFF80BEFF),
+      tertiary: Color(0xFF608FBF)),
   ThemePreset(
-    name: 'Dark Blue',
-    primary: Color(0xFFA6AAFF),
-    secondary: Color(0xFF666EFF),
-    tertiary: Color(0xFF4D52BF)),
+      name: 'Dark Blue',
+      primary: Color(0xFFA6AAFF),
+      secondary: Color(0xFF666EFF),
+      tertiary: Color(0xFF4D52BF)),
   ThemePreset(
-    name: 'Purple',
-    primary: Color(0xFFD1B3FF),
-    secondary: Color(0xFFB280FF),
-    tertiary: Color(0xFF8560BF)),
+      name: 'Purple',
+      primary: Color(0xFFD1B3FF),
+      secondary: Color(0xFFB280FF),
+      tertiary: Color(0xFF8560BF)),
 ];

--- a/lib/util/day_watcher.dart
+++ b/lib/util/day_watcher.dart
@@ -1,35 +1,22 @@
 import '../exports/package_exports.dart';
-import '../exports/theme_exports.dart';
-import '../exports/page_exports.dart';
-import '../exports/util_exports.dart';
 
 class DayWatcher {
   final void Function(DateTime newLogicalDay) onDayChanged;
-  final SettingsProvider settingsProvider;
   Timer? _timer;
   late DateTime _lastLogicalDay;
 
-  DayWatcher({required this.onDayChanged, required this.settingsProvider}) {
+  DayWatcher({required this.onDayChanged}) {
     _lastLogicalDay = _getLogicalDate(DateTime.now());
+
+    onDayChanged(_lastLogicalDay);
+
     _startListening();
   }
 
   DateTime _getLogicalDate(DateTime now) {
-    final start = _parseHour(settingsProvider.dayStartHour);
-    final dayStartDateTime =
-        DateTime(now.year, now.month, now.day, start.hour, start.minute);
-
-    if (now.isBefore(dayStartDateTime)) {
-      final previousDay = now.subtract(Duration(days: 1));
-      return DateTime(previousDay.year, previousDay.month, previousDay.day);
-    }
-
-    return DateTime(now.year, now.month, now.day);
-  }
-
-  TimeOfDay _parseHour(String hourString) {
-    final parts = hourString.split(':');
-    return TimeOfDay(hour: int.parse(parts[0]), minute: int.parse(parts[1]));
+    return now.hour < 3
+        ? DateTime(now.year, now.month, now.day - 1)
+        : DateTime(now.year, now.month, now.day);
   }
 
   DateTime getLogicalDate(DateTime now) => _getLogicalDate(now);

--- a/lib/util/functions.dart
+++ b/lib/util/functions.dart
@@ -6,11 +6,6 @@ import '../exports/util_exports.dart';
 class Functions {
   String dateDay = DateFormat('EEEE').format(DateTime.now());
 
-  Future<String> getUserName() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString('username') ?? '';
-  }
-
   String getGreeting(String name) {
     final hour = DateTime.now().hour;
     String baseGreeting;
@@ -58,11 +53,6 @@ class Functions {
     }
   }
 
-  Future<void> saveUserName(String name) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('username', name);
-  }
-
   Future<User?> register(String name, String email, String password) async {
     debugLog('[Register] User is being registered..');
     try {
@@ -72,7 +62,7 @@ class Functions {
         password: password,
       );
       await userCredential.user!.updateDisplayName(name);
-      print('[Register] User succesfully registered, redirecting..');
+      debugLog('[Register] User succesfully registered, redirecting..');
       return userCredential.user;
     } on FirebaseAuthException catch (e) {
       throw Exception(e.message ?? '[Register] User registration failed');


### PR DESCRIPTION
Removed dayStart from Settings, default 'new day' set to 3 am. Overcomplicated feature that will rarely be used. Removed unnecessary imports.
Removed outdated username code.

Added debug page to test various features. Navigation to debug page is available through a button on the settings page, only visible if debugMode is enabled. Moved theme color test containers to debug page.
Default tasks are now preloaded on the Settings page, ensuring the data is available when navigating to the lists. Updated Task-list to use logicalDay based on the dayWatcher. E.g. the 'previous' day if it's between 00-03 am. Updated userName to pull the name from database in build, instead of navigation